### PR TITLE
increase speed by using builtin arithmetic

### DIFF
--- a/mbrot.go
+++ b/mbrot.go
@@ -5,7 +5,7 @@ import (
 	"image/color"
 	"image/png"
 	"log"
-	"math/cmplx"
+//	"math/cmplx"
 	"math/rand"
 	"net/http"
 	"strconv"
@@ -43,10 +43,10 @@ func init() {
 func escape(c complex128) int {
 	z := c
 	for i := 0; i < MaxEscape-1; i++ {
-		if cmplx.Abs(z) > 2 {
+		if real(z)*real(z)+imag(z)+imag(z) > 4 {
 			return i
 		}
-		z = cmplx.Pow(z, 2) + c
+		z = z*z + c
 	}
 	return MaxEscape - 1
 }

--- a/mbrot_test.go
+++ b/mbrot_test.go
@@ -1,0 +1,9 @@
+package main
+import (
+	"testing"
+)
+func BenchmarkEscape(b *testing.B){
+	for i:=0;i<b.N;i++ {
+		escape(0.35+0.21i)
+	}
+}


### PR DESCRIPTION
The code runs a lot quicker if you used `z*z` for squaring, and a little quicker if you save a square root by testing for  |z|^2.  These commits also mean that the cmplx import can be removed. The code only uses builtin operations.

I've also written a very short benchmark. This makes the generation of a Mandelbrot about 5 times quicker, which makes a difference on an r-pi.